### PR TITLE
Fix signup import paths

### DIFF
--- a/b2b/web-app/apps/business-admin-app/pages/api/organizations/deleteTeam.ts
+++ b/b2b/web-app/apps/business-admin-app/pages/api/organizations/deleteTeam.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getConfig } from "@pet-management-webapp/business-admin-app/util/util-application-config-util";
+import { getConfig } from "@pet-management-webapp/util-application-config-util";
 
 /**
  * API route to delete an organization

--- a/b2b/web-app/pages/api/createTeam/addTeam.ts
+++ b/b2b/web-app/pages/api/createTeam/addTeam.ts
@@ -1,9 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-<<<<<<<< HEAD:b2b/web-app/apps/business-admin-app/pages/api/organizations/addTeam.ts
-import { getConfig } from "@pet-management-webapp/business-admin-app/util/util-application-config-util";
-========
-import { getConfig, getHostedUrl } from "@pet-management-webapp/util-application-config-util";
->>>>>>>> d1ac4ead778f1f08ac768af16f63ed1af52d6b8f:b2b/web-app/pages/api/createTeam/addTeam.ts
+import { getConfig } from "@pet-management-webapp/util-application-config-util";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method !== 'POST') {

--- a/b2b/web-app/pages/api/signup.ts
+++ b/b2b/web-app/pages/api/signup.ts
@@ -19,9 +19,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { notPostError } from "@pet-management-webapp/shared/data-access/data-access-common-api-util";
 import getToken from "./clientCredentials";
-import validateOrgName from "./organizations/checkName";
-import deleteTeam from "./organizations/deleteTeam";
-import createOrg from "./organizations/addTeam";
+import validateOrgName from "./createTeam/checkName";
+import deleteTeam from "../../apps/business-admin-app/pages/api/organizations/deleteTeam";
+import createOrg from "./createTeam/addTeam";
 import listCurrentApplication from "./settings/application/listCurrentApplication";
 import getRole from "./settings/role/getRole";
 import switchOrg from "./settings/switchOrg";


### PR DESCRIPTION
## Summary
- fix merge markers in `addTeam.ts`
- update signup API to point to proper paths for organization helper functions

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6876514bc3808330bad741dad8c8a011