### PR TITLE
Integrate Asgardeo React SDK

### DIFF
--- a/b2b/web-app/ConfigContext.tsx
+++ b/b2b/web-app/ConfigContext.tsx
@@ -1,0 +1,10 @@
+import React, { createContext, useContext, ReactNode } from "react";
+import { AsgardeoConfig } from "./config-loader";
+
+const ConfigContext = createContext<AsgardeoConfig | null>(null);
+
+export const ConfigProvider = ({ config, children }:{ config: AsgardeoConfig; children: ReactNode; }) => (
+    <ConfigContext.Provider value={config}>{children}</ConfigContext.Provider>
+);
+
+export const useConfig = () => useContext(ConfigContext);

--- a/b2b/web-app/config-loader.ts
+++ b/b2b/web-app/config-loader.ts
@@ -1,0 +1,15 @@
+export interface AsgardeoConfig {
+  clientID: string;
+  baseUrl: string;
+  signInRedirectURL: string;
+  signOutRedirectURL: string;
+  scope: string[];
+}
+
+export const loadConfig = async (): Promise<AsgardeoConfig> => {
+  const response = await fetch("/runtime-config.json");
+  if (!response.ok) {
+    throw new Error("Failed to load runtime config");
+  }
+  return await response.json();
+};

--- a/b2b/web-app/package.json
+++ b/b2b/web-app/package.json
@@ -59,6 +59,7 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
     "remark-gfm": "^4.0.1",
+    "@asgardeo/auth-react": "^2.0.4",
     "rsuite": "^5.22.2",
     "rsuite-color-picker": "^0.2.0",
     "styled-components": "^5.3.10",

--- a/b2b/web-app/pages/_app.tsx
+++ b/b2b/web-app/pages/_app.tsx
@@ -18,28 +18,44 @@
 import { getConfig } from "@pet-management-webapp/util-application-config-util";
 import { SessionProvider } from "next-auth/react";
 import Head from "next/head";
+import React, { useEffect, useState } from "react";
+import { AuthProvider } from "@asgardeo/auth-react";
+import { ConfigProvider } from "../ConfigContext";
+import { loadConfig, AsgardeoConfig } from "../config-loader";
 import "rsuite/dist/rsuite.min.css";
 import "../styles/custom-theme.less";
 import "../styles/globals.css";
 
 function MyApp(prop) {
-
     const { Component, pageProps } = prop;
+    const [ config, setConfig ] = useState<AsgardeoConfig | null>(null);
+
+    useEffect(() => {
+        loadConfig().then(setConfig).catch((err) => console.error(err));
+    }, []);
+
+    if (!config) {
+        return null;
+    }
 
     return (
         <SessionProvider session={ pageProps ? pageProps.session : null }>
-            <Head>
-                <link rel="shortcut icon" href="./favicon.png" />
-                <meta httpEquiv="cache-control" content="no-cache" />
-                <meta httpEquiv="expires" content="0" />
-                <meta httpEquiv="pragma" content="no-cache" />
-                <title>{ getConfig().BusinessAdminAppConfig.ApplicationConfig.Branding.name }</title>
-                <meta
-                    name="description" 
-                    content={ getConfig().BusinessAdminAppConfig.ApplicationConfig.Branding.name } />
-            </Head>
+            <ConfigProvider config={ config }>
+                <AuthProvider config={ config }>
+                    <Head>
+                        <link rel="shortcut icon" href="./favicon.png" />
+                        <meta httpEquiv="cache-control" content="no-cache" />
+                        <meta httpEquiv="expires" content="0" />
+                        <meta httpEquiv="pragma" content="no-cache" />
+                        <title>{ getConfig().BusinessAdminAppConfig.ApplicationConfig.Branding.name }</title>
+                        <meta
+                            name="description"
+                            content={ getConfig().BusinessAdminAppConfig.ApplicationConfig.Branding.name } />
+                    </Head>
 
-            <Component { ...pageProps } />
+                    <Component { ...pageProps } />
+                </AuthProvider>
+            </ConfigProvider>
         </SessionProvider>
     );
 }

--- a/b2b/web-app/pages/signin.tsx
+++ b/b2b/web-app/pages/signin.tsx
@@ -17,7 +17,7 @@
  */
 import { LogoComponent } from "@pet-management-webapp/ui-components";
 import { SigninRedirectComponent } from "@pet-management-webapp/shared/ui/ui-components";
-import { orgSignin } from "@pet-management-webapp/shared/util/util-authorization-config-util";
+import { useAuthContext } from "@asgardeo/auth-react";
 import React, { useEffect, useState } from "react";
 import "rsuite/dist/rsuite.min.css";
 
@@ -29,6 +29,7 @@ export default function Signin() {
 
     const moveTime = 40;
     const [ redirectSeconds, setRedirectSeconds ] = useState<number>(moveTime);
+    const { signIn } = useAuthContext();
 
     const getOrgIdFromUrl = (): string => {
         const currentUrl = window.location.href;
@@ -41,19 +42,20 @@ export default function Signin() {
 
     useEffect(() => {
         if (redirectSeconds <= 1) {
-            if (getOrgIdFromUrl()) {
-                orgSignin(true, getOrgIdFromUrl());
+            const orgId = getOrgIdFromUrl();
+            if (orgId) {
+                signIn({ orgId });
             } else {
-                orgSignin(true);
+                signIn();
             }
 
             return;
         }
 
         setTimeout(() => {
-            setRedirectSeconds((redirectSeconds) => redirectSeconds - 1);
+            setRedirectSeconds((prev) => prev - 1);
         }, moveTime);
-    }, [ redirectSeconds ]);
+    }, [ redirectSeconds, signIn ]);
 
     return (
         <SigninRedirectComponent

--- a/b2b/web-app/public/runtime-config.json
+++ b/b2b/web-app/public/runtime-config.json
@@ -1,0 +1,7 @@
+{
+  "clientID": "<ASGARDEO_CLIENT_ID>",
+  "baseUrl": "https://api.asgardeo.io/t/<org_name>",
+  "signInRedirectURL": "http://localhost:3002",
+  "signOutRedirectURL": "http://localhost:3002",
+  "scope": ["openid", "profile", "email"]
+}


### PR DESCRIPTION
## Summary
- add Asgardeo React SDK to dependencies
- load runtime configuration for Asgardeo
- wrap application with Asgardeo `AuthProvider`
- trigger Asgardeo login in `signin` page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687e63ef49588330bab7e42898e0a5ea